### PR TITLE
refactor: add export params types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from './events';
+export * from './interfaces/widget-parameters'
 export {makeSignatureString} from './helpers/makeSignatureString';
 export {NearPay} from './sdk/near-pay';
 export {isNearpayEvent} from './helpers/isNearpayEvent';


### PR DESCRIPTION
better importing types

```ts
import { WidgetParams } from '@nearpay/nearpay-sdk'
```

instead of 
```ts
import { WidgetParams } from '@nearpay/nearpay-sdk/dist/interfaces/widget-parameters'
```